### PR TITLE
Add SCSS styles to Svelte preprocess

### DIFF
--- a/scripts/compile/svelte.js
+++ b/scripts/compile/svelte.js
@@ -36,7 +36,9 @@ module.exports = {
                             options: {
                                 emitCss: true,
                                 preprocess: SveltePreprocess({
-                                    scss: true,
+                                    scss: {
+                                        prependData: `@import 'src/${graphic.name}/sass/style.scss';`
+                                    },
                                     sass: true
                                 })
                             }

--- a/src/graphic/svelte/App.svelte
+++ b/src/graphic/svelte/App.svelte
@@ -14,12 +14,12 @@
 	.messages {
 		.typescript {
 			color: white;
-			background-color: #3F74BA;
+			background-color: $c-lead;
 		}
 
 		.scss {
 			color: white;
-			background-color: #BA6993;
+			background-color: $c-plum;
 		}
 	}
 </style>


### PR DESCRIPTION
Prepend SCSS to Svelte styles so existing SCSS variables can be used in Svelte. 